### PR TITLE
Bluetooth: Mesh: Use PSA API for AES ECB and CCM encryption

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -35,7 +35,7 @@ config BT_MESH_USES_MBEDTLS_PSA
 	select MBEDTLS_MAC_CMAC_ENABLED
 	select MBEDTLS_CIPHER_AES_ENABLED
 	select MBEDTLS_AES_ROM_TABLES
-	select BT_HOST_CCM
+	select MBEDTLS_CIPHER_CCM_ENABLED
 	help
 	  Use mbed TLS library to perform crypto operations.
 

--- a/subsys/bluetooth/mesh/crypto.h
+++ b/subsys/bluetooth/mesh/crypto.h
@@ -12,6 +12,16 @@ struct bt_mesh_sg {
 
 int bt_mesh_crypto_init(void);
 
+int bt_mesh_encrypt(const uint8_t key[16], const uint8_t plaintext[16], uint8_t enc_data[16]);
+
+int bt_mesh_ccm_encrypt(const uint8_t key[16], uint8_t nonce[13],
+			const uint8_t *plaintext, size_t len, const uint8_t *aad,
+			size_t aad_len, uint8_t *enc_data, size_t mic_size);
+
+int bt_mesh_ccm_decrypt(const uint8_t key[16], uint8_t nonce[13],
+			const uint8_t *enc_data, size_t len, const uint8_t *aad,
+			size_t aad_len, uint8_t *plaintext, size_t mic_size);
+
 int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
 			size_t sg_len, uint8_t mac[16]);
 

--- a/subsys/bluetooth/mesh/crypto_tc.c
+++ b/subsys/bluetooth/mesh/crypto_tc.c
@@ -15,12 +15,33 @@
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dh.h>
 
+#include <zephyr/bluetooth/crypto.h>
+
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_CRYPTO)
 #define LOG_MODULE_NAME bt_mesh_tc_crypto
 #include "common/log.h"
 
 #include "mesh.h"
 #include "crypto.h"
+
+int bt_mesh_encrypt(const uint8_t key[16], const uint8_t plaintext[16], uint8_t enc_data[16])
+{
+	return bt_encrypt_be(key, plaintext, enc_data);
+}
+
+int bt_mesh_ccm_encrypt(const uint8_t key[16], uint8_t nonce[13],
+			const uint8_t *plaintext, size_t len, const uint8_t *aad,
+			size_t aad_len, uint8_t *enc_data, size_t mic_size)
+{
+	return bt_ccm_encrypt(key, nonce, plaintext, len, aad, aad_len, enc_data, mic_size);
+}
+
+int bt_mesh_ccm_decrypt(const uint8_t key[16], uint8_t nonce[13],
+			const uint8_t *enc_data, size_t len, const uint8_t *aad,
+			size_t aad_len, uint8_t *plaintext, size_t mic_size)
+{
+	return bt_ccm_decrypt(key, nonce, enc_data, len, aad, aad_len, plaintext, mic_size);
+}
 
 int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
 			size_t sg_len, uint8_t mac[16])

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -30,6 +30,7 @@
 #include "access.h"
 #include "proxy.h"
 #include "proxy_msg.h"
+#include "crypto.h"
 
 #if defined(CONFIG_BT_MESH_PROXY_USE_DEVICE_NAME)
 #define ADV_OPT_USE_NAME BT_LE_ADV_OPT_USE_NAME
@@ -442,8 +443,7 @@ static int node_id_adv(struct bt_mesh_subnet *sub, int32_t duration)
 	memcpy(tmp + 6, proxy_svc_data + 11, 8);
 	sys_put_be16(bt_mesh_primary_addr(), tmp + 14);
 
-	err = bt_encrypt_be(sub->keys[SUBNET_KEY_TX_IDX(sub)].identity, tmp,
-			    tmp);
+	err = bt_mesh_encrypt(sub->keys[SUBNET_KEY_TX_IDX(sub)].identity, tmp, tmp);
 	if (err) {
 		return err;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
@@ -381,6 +381,7 @@ static void test_tx_invalid(void)
 	int err;
 
 	bt_mesh_test_cfg_set(&tx_cfg, 130);
+	bt_mesh_crypto_init();
 	k_sem_init(&observer_sem, 0, 1);
 
 	err = bt_enable(NULL);
@@ -489,6 +490,7 @@ static void test_tx_kr_old_key(void)
 	int err;
 
 	bt_mesh_test_cfg_set(&tx_cfg, 170);
+	bt_mesh_crypto_init();
 	k_sem_init(&observer_sem, 0, 1);
 
 	err = bt_enable(NULL);
@@ -678,6 +680,7 @@ static void test_tx_multiple_netkeys(void)
 	int err;
 
 	bt_mesh_test_cfg_set(&tx_cfg, 340);
+	bt_mesh_crypto_init();
 	k_sem_init(&observer_sem, 0, 1);
 
 	err = bt_enable(NULL);
@@ -840,6 +843,7 @@ static void test_rx_secure_beacon_interval(void)
 	int64_t delta;
 
 	bt_mesh_test_cfg_set(&rx_cfg, 750);
+	bt_mesh_crypto_init();
 	k_sem_init(&observer_sem, 0, 1);
 	k_work_init_delayable(&beacon_timer, secure_beacon_send);
 


### PR DESCRIPTION
This commit replaces usage of AES ECB and AES CCM encryption algorithms
from tinycrypt based BT Host implementation to PSA API over mbed TLS.