### PR TITLE
Bluetooth: Mesh: change default receive delay for legacy adv

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -728,6 +728,7 @@ config BT_MESH_LPN_MIN_QUEUE_SIZE
 config BT_MESH_LPN_RECV_DELAY
 	int "Receive delay requested by the local node"
 	range 10 255
+	default 120 if BT_MESH_ADV_LEGACY
 	default 100
 	help
 	  The ReceiveDelay is the time between the Low Power node


### PR DESCRIPTION
The legacy advertiser has the issue when it might send frame one more time. It causes the situation when LPN sends one more spurious Poll frame but Friend node has already started sending data after receive delay.
The collision happens and LPN has to send one more Poll to request data one more time. To prevent this the receive delay has been extended on 20 ms for the legacy advertiser. That allows LPN complete sending even the sporious frame if it happened. This additional time is correct only for default BT_MESH_NETWORK_TRANSMIT_INTERVAL.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>