### PR TITLE
Bluetooth: Mesh: redesign key id assignment

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -46,6 +46,22 @@ config BT_MESH_USES_MBEDTLS_PSA
 
 endchoice
 
+if BT_MESH_USES_MBEDTLS_PSA
+
+config BT_MESH_PSA_KEY_ID_USER_MIN_OFFSET
+	int "Offset of BLE Mesh key id range regarding PSA_KEY_ID_USER_MIN"
+	default 0
+	help
+	  The PSA specification mandates to set key identifiers for keys
+	  with persistent lifetime. The users of the PSA API is responsible
+	  (BLE Mesh is user of PSA API) to provide correct and unique identifiers.
+	  The BLE Mesh identifier range should be between PSA_KEY_ID_USER_MIN and
+	  PSA_KEY_ID_USER_MAX. BLE Mesh requires two ids for each subnetwork, two ids
+	  for each application key, and one id for the device key.
+	  It should consider the Mesh Configuration Database instances if database enabled.
+
+endif # BT_MESH_USES_MBEDTLS_PSA
+
 # Virtual option enabled whenever Generic Provisioning layer is needed
 config BT_MESH_PROV
 	bool

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -392,6 +392,7 @@ static int app_id_set(struct app_key *app, int key_idx, const struct bt_mesh_key
 	}
 
 	memcpy(&app->keys[key_idx].val, key, sizeof(struct bt_mesh_key));
+	bt_mesh_key_assign(&app->keys[key_idx].val);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -21,6 +21,7 @@
 #include "net.h"
 #include "rpl.h"
 #include "settings.h"
+#include "keys.h"
 
 /* Tracking of what storage changes are pending for App and Net Keys. We
  * track this in a separate array here instead of within the respective
@@ -243,6 +244,7 @@ static int cdb_node_set(const char *name, size_t len_rd,
 
 	memcpy(node->uuid, val.uuid, 16);
 	memcpy(&node->dev_key, &val.dev_key, sizeof(struct bt_mesh_key));
+	bt_mesh_key_assign(&node->dev_key);
 
 	BT_DBG("Node 0x%04x recovered from storage", addr);
 
@@ -289,6 +291,8 @@ static int cdb_subnet_set(const char *name, size_t len_rd,
 		sub->kr_phase = key.kr_phase;
 		memcpy(&sub->keys[0].net_key, &key.val[0], sizeof(struct bt_mesh_key));
 		memcpy(&sub->keys[1].net_key, &key.val[1], sizeof(struct bt_mesh_key));
+		bt_mesh_key_assign(&sub->keys[0].net_key);
+		bt_mesh_key_assign(&sub->keys[1].net_key);
 
 		return 0;
 	}
@@ -302,6 +306,8 @@ static int cdb_subnet_set(const char *name, size_t len_rd,
 	sub->kr_phase = key.kr_phase;
 	memcpy(&sub->keys[0].net_key, &key.val[0], sizeof(struct bt_mesh_key));
 	memcpy(&sub->keys[1].net_key, &key.val[1], sizeof(struct bt_mesh_key));
+	bt_mesh_key_assign(&sub->keys[0].net_key);
+	bt_mesh_key_assign(&sub->keys[1].net_key);
 
 	BT_DBG("NetKeyIndex 0x%03x recovered from storage", net_idx);
 
@@ -353,6 +359,8 @@ static int cdb_app_key_set(const char *name, size_t len_rd,
 
 	memcpy(&app->keys[0].app_key, &key.val[0], sizeof(struct bt_mesh_key));
 	memcpy(&app->keys[1].app_key, &key.val[1], sizeof(struct bt_mesh_key));
+	bt_mesh_key_assign(&app->keys[0].app_key);
+	bt_mesh_key_assign(&app->keys[1].app_key);
 
 	BT_DBG("AppKeyIndex 0x%03x recovered from storage", app_idx);
 

--- a/subsys/bluetooth/mesh/keys.h
+++ b/subsys/bluetooth/mesh/keys.h
@@ -7,6 +7,7 @@
 #if defined CONFIG_BT_MESH_USES_MBEDTLS_PSA
 
 int bt_mesh_key_export(uint8_t out[16], const struct bt_mesh_key *in);
+void bt_mesh_key_assign(struct bt_mesh_key *key);
 int bt_mesh_key_destroy(struct bt_mesh_key *key);
 int bt_mesh_key_compare(const uint8_t raw_key[16], struct bt_mesh_key *mesh_key);
 
@@ -17,6 +18,9 @@ static inline int bt_mesh_key_export(uint8_t out[16], const struct bt_mesh_key *
 	memcpy(out, in, 16);
 	return 0;
 }
+
+static inline void bt_mesh_key_assign(struct bt_mesh_key *key)
+{}
 
 static inline int bt_mesh_key_destroy(struct bt_mesh_key *key)
 {

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -933,6 +933,7 @@ static int net_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	}
 
 	memcpy(&bt_mesh.dev_key, &net.dev_key, sizeof(struct bt_mesh_key));
+	bt_mesh_key_assign(&bt_mesh.dev_key);
 	bt_mesh_comp_provision(net.primary_addr);
 
 	BT_DBG("Provisioned with primary address 0x%04x", net.primary_addr);

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -25,6 +25,7 @@
 #include "foundation.h"
 #include "settings.h"
 #include "access.h"
+#include "keys.h"
 
 #define CID_NVAL   0xffff
 
@@ -1162,7 +1163,7 @@ static int cmd_net_key_add(const struct shell *shell, size_t argc, char *argv[])
 				return 0;
 			}
 
-			if (bt_mesh_key_export(key_val, subnet->keys[0].net_key)) {
+			if (bt_mesh_key_export(key_val, &subnet->keys[0].net_key)) {
 				shell_error(shell,
 					    "Unable to export key from subnet 0x%03x",
 					    key_net_idx);
@@ -1337,7 +1338,7 @@ static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 				return 0;
 			}
 
-			if (bt_mesh_key_export(key_val, app_key->keys[0].app_key)) {
+			if (bt_mesh_key_export(key_val, &app_key->keys[0].app_key)) {
 				shell_error(shell,
 					    "Unable to export app key 0x%03x",
 					    key_app_idx);
@@ -3110,7 +3111,7 @@ static void cdb_print_nodes(const struct shell *shell)
 
 		total++;
 		bin2hex(node->uuid, 16, uuid_hex_str, sizeof(uuid_hex_str));
-		if (bt_mesh_key_export(raw_dev_key, node->dev_key)) {
+		if (bt_mesh_key_export(raw_dev_key, &node->dev_key)) {
 			shell_error(shell, "Unable to export key from node 0x%04x", node->addr);
 			continue;
 		}
@@ -3139,7 +3140,7 @@ static void cdb_print_subnets(const struct shell *shell)
 			continue;
 		}
 
-		if (bt_mesh_key_export(raw_key, subnet->keys[0].net_key)) {
+		if (bt_mesh_key_export(raw_key, &subnet->keys[0].net_key)) {
 			shell_error(shell, "Unable to export key from subnet 0x%03x",
 					subnet->net_idx);
 			continue;
@@ -3170,7 +3171,7 @@ static void cdb_print_app_keys(const struct shell *shell)
 			continue;
 		}
 
-		if (bt_mesh_key_export(raw_key, app_key->keys[0].app_key)) {
+		if (bt_mesh_key_export(raw_key, &app_key->keys[0].app_key)) {
 			shell_error(shell, "Unable to export app key 0x%03x",
 					app_key->app_idx);
 			continue;
@@ -3347,8 +3348,8 @@ static int cmd_cdb_subnet_del(const struct shell *shell, size_t argc,
 		return 0;
 	}
 
-	bt_mesh_key_destroy(sub->keys[0].net_key);
-	bt_mesh_key_destroy(sub->keys[1].net_key);
+	bt_mesh_key_destroy(&sub->keys[0].net_key);
+	bt_mesh_key_destroy(&sub->keys[1].net_key);
 	bt_mesh_cdb_subnet_del(sub, true);
 
 	shell_print(shell, "Deleted subnet 0x%03x", net_idx);
@@ -3421,8 +3422,8 @@ static int cmd_cdb_app_key_del(const struct shell *shell, size_t argc,
 		return 0;
 	}
 
-	bt_mesh_key_destroy(key->keys[0].app_key);
-	bt_mesh_key_destroy(key->keys[1].app_key);
+	bt_mesh_key_destroy(&key->keys[0].app_key);
+	bt_mesh_key_destroy(&key->keys[1].app_key);
 	bt_mesh_cdb_app_key_del(key, true);
 
 	shell_print(shell, "Deleted AppKey 0x%03x", app_idx);

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -319,6 +319,8 @@ static int net_keys_create(struct bt_mesh_subnet_keys *keys,
 			BT_ERR("Unable to import network key");
 			return err;
 		}
+	} else {
+		bt_mesh_key_assign(&keys->net);
 	}
 
 	BT_DBG("NID 0x%02x EncKey %s",
@@ -645,12 +647,12 @@ static int subnet_key_set(struct bt_mesh_subnet *sub, int key_idx, const struct 
 		return err;
 	}
 
+	memcpy(&sub->keys[key_idx].net, key, sizeof(struct bt_mesh_key));
+
 	err = net_keys_create(&sub->keys[key_idx], false, raw_key);
 	if (err) {
 		return err;
 	}
-
-	memcpy(&sub->keys[key_idx].net, key, sizeof(struct bt_mesh_key));
 
 	return 0;
 }


### PR DESCRIPTION
The current approach of the key id assignment breaks the key id array consistency after the device rebooting. This PR redesigns the approach of key id management.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>